### PR TITLE
Added Bottom Navigation Bar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,22 +7,49 @@ import 'package:university/screens/auth/sign_in_screen.dart';
 import 'package:university/screens/mentor/mentor_screen.dart';
 import 'package:university/screens/home/home_screen.dart';
 import 'package:university/screens/mentor/widgets/mentor_preview_widget.dart';
+import 'package:university/screens/mentor/widgets/mentor_widget_extended.dart';
 import 'package:university/screens/pathway/pathway_screen.dart';
 import 'package:university/services/firebase_auth_service.dart';
+import 'package:university/screens/bottom_navigation.dart';
+
+// List of Screens to be Shown
+List<Widget> screens = <Widget>[
+  HomeScreen(),
+  MentorScreen(),
+];
 
 void main() {
   runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
+// Also converted MyApp to stateful widget
+class MyApp extends StatefulWidget {
   const MyApp({Key? key}) : super(key: key);
 
-  // This widget is the root of your application.
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  // For the functionality of the NavBar
+  int _selectedIndex = 0;
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
       debugShowCheckedModeBanner: false,
-      home: MentorWidget(),
+      home: Scaffold(
+        body: screens[_selectedIndex],
+        bottomNavigationBar: BottomNavBar(
+          selectedIndex: _selectedIndex,
+          onTap: _onItemTapped,
+        ),
+      ),
     );
     // return FutureBuilder(
     //   future: Firebase.initializeApp(),

--- a/lib/screens/bottom_navigation.dart
+++ b/lib/screens/bottom_navigation.dart
@@ -1,0 +1,48 @@
+// ignore_for_file: prefer_const_constructors
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:university/constants/constants.dart';
+import 'package:university/main.dart';
+import 'package:university/screens/home/home_screen.dart';
+import 'package:university/screens/mentor/mentor_screen.dart';
+
+//Future Upgrades can be to use animations while changing the screens
+
+class BottomNavBar extends StatelessWidget {
+  final int selectedIndex;
+  final void Function(int) onTap;
+  const BottomNavBar({Key? key, required this.onTap, this.selectedIndex = 0})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      backgroundColor: Colors.blue.shade400,
+      selectedIconTheme: IconThemeData(size: 27.0),
+      selectedItemColor: Colors.black87,
+      selectedLabelStyle: TextStyle(
+        color: Colors.black87,
+        fontSize: 15.0,
+        fontWeight: FontWeight.bold,
+        letterSpacing: 0.7,
+      ),
+      unselectedItemColor: Colors.black45,
+      showUnselectedLabels: false,
+      onTap: onTap,
+      currentIndex: selectedIndex,
+      items: [
+        BottomNavigationBarItem(
+          icon: Icon(Icons.home_outlined),
+          activeIcon: Icon(Icons.home),
+          label: 'Home',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.person_outline),
+          activeIcon: Icon(Icons.person),
+          label: 'Mentors',
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Created a Bottom Navigation Bar inside the `screen` folder in the file `bottom_navigation.dart`.
Also modified `main.dart` a bit for testing purposes (this file should later be changed to screen after authorization/sign in).
Future upgrades can be to use some awesome external packages for screen animations while onTap.

Here is the preview of the navigation bar:
![ezgif-2-62c32cd4d4d0](https://user-images.githubusercontent.com/69782292/135662345-3ef60f9d-24e6-4a92-ad15-f29fa83a4353.gif)

