### PR TITLE
Added support for RouteGenerator

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:university/auth_widget_builder.dart';
 import 'package:university/screens/auth/auth_widget.dart';
 import 'package:university/services/firebase_auth_service.dart';
+import 'package:university/services/route_generator.dart';
 
 void main() {
   runApp(const MyApp());
@@ -32,6 +33,8 @@ class MyApp extends StatelessWidget {
             child: AuthWidgetBuilder(builder: (context, userSnapshot) {
               return MaterialApp(
                 debugShowCheckedModeBanner: false,
+                // initialRoute: '/',
+                onGenerateRoute: RouteGenerator.generate,
                 home: AuthWidget(userSnapshot: userSnapshot),
               );
             }),

--- a/lib/screens/bottom_navigation.dart
+++ b/lib/screens/bottom_navigation.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:university/constants/constants.dart';
 import 'package:university/models/user_model.dart';
@@ -55,16 +56,10 @@ class _BottomNavigationState extends State<BottomNavigation> {
                 ),
               ),
               GestureDetector(
-                onTap: () => Navigator.push(
+                onTap: () => Navigator.pushNamed(
                   context,
-                  MaterialPageRoute(
-                    builder: (context) => ProfilePage(
-                      name: userData.name,
-                      isMentor: false,
-                      imgUrl: userData.imgurl,
-                      email: userData.email,
-                    ),
-                  ),
+                  '/profile',
+                  arguments: [userData.name, false, userData.imgurl, userData.email],
                 ),
                 child: CircleAvatar(
                   backgroundImage: NetworkImage(userData.imgurl),

--- a/lib/screens/error_screen.dart
+++ b/lib/screens/error_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class ErrorScreen extends StatefulWidget {
+  const ErrorScreen({Key? key}) : super(key: key);
+
+  @override
+  _ErrorScreenState createState() => _ErrorScreenState();
+}
+
+class _ErrorScreenState extends State<ErrorScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text("This is the error screen."),
+    );
+  }
+}

--- a/lib/screens/mentor/widgets/explore_pathway.dart
+++ b/lib/screens/mentor/widgets/explore_pathway.dart
@@ -42,8 +42,7 @@ class ExplorePathWay extends StatelessWidget {
           ),
           InkWell(
             onTap: () {
-              Navigator.push(context,
-                  MaterialPageRoute(builder: (_) => const PathwayScreen()));
+              Navigator.pushNamed(context, '/pathway');
             },
             child: Container(
               width: 300,

--- a/lib/services/route_generator.dart
+++ b/lib/services/route_generator.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:university/screens/auth/sign_in_screen.dart';
+import 'package:university/screens/error_screen.dart';
+import 'package:university/screens/home/home_screen.dart';
+import 'package:university/screens/mentor/mentor_screen.dart';
+import 'package:university/screens/pathway/pathway_screen.dart';
+import 'package:university/screens/profile/profile_screen.dart';
+import 'package:university/screens/roadmap_form/roadmap_form.dart';
+
+class RouteGenerator {
+  static Route<dynamic> generate(RouteSettings settings) {
+    final args = settings.arguments;
+
+    switch(settings.name) {
+      case '/': return MaterialPageRoute(builder: (_)=> SignInScreen());
+      case '/home': return MaterialPageRoute(builder: (_)=>HomeScreen());
+      case '/mentor': return MaterialPageRoute(builder: (_)=>MentorScreen());
+      case '/pathway': return MaterialPageRoute(builder: (_)=> PathwayScreen());
+      case '/roadmap': return MaterialPageRoute(builder: (_)=> RoadmapDetailsForm());
+      case '/profile':
+        List<dynamic> details = args as List<dynamic>;
+        return MaterialPageRoute(builder: (_)=> ProfilePage(
+            name: details[0],
+            isMentor: details[1],
+            imgUrl: details[2],
+            email: details[3],
+        ));
+      default: return MaterialPageRoute(builder: (_)=> ErrorScreen());
+    }
+  }
+}


### PR DESCRIPTION
## Description
This pull request adds support for `RouteGenerator` by which we can use named routes to navigate to other screens. 

Changes I have made : 

- Added a new class in `lib/services/route_generator.dart`. This contains the backend logic of RouteGenerators.
- Added an error screen in `lib/screens/error_screen.dart` to show when wrong named routes are used to access some screens.
- Updated the navigation code to `ProfilePage` screen.
- Updated the navigation code to `Pathway` screen.

## Related Issues
Fixes issue #49 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide].
- [x] I updated/added relevant comments in code.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.
